### PR TITLE
Remove Test::Mock version from META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -40,7 +40,7 @@
 	],
 	"license": "Artistic-2.0",
 	"test-depends": [
-		"Test::Mock:ver<1.4>",
+		"Test::Mock",
 		"Test::META"
 	],
 	"provides": {


### PR DESCRIPTION
Test::Mock doesn't appear to have previous versions available on the ecosystem.

```
zef install 'Test::Mock:ver<1.4>'
===> Searching for: Test::Mock:ver<1.4>
===> Updating cpan mirror: https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/cpan1.json
===> Updating p6c mirror: https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/p6c1.json
===> Updated p6c mirror: https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/p6c1.json
===> Updated cpan mirror: https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/cpan1.json
No candidates found matching identity: Test::Mock:ver<1.4>
```